### PR TITLE
Add “Save to Local” Button to Prevent Losing Work

### DIFF
--- a/maps/index.html
+++ b/maps/index.html
@@ -7,6 +7,9 @@
 
 <body>
 	<div id="root"></div>
+	<div id="controls">
+		<button id="save-local-button">Save to Local</button>
+	</div>
 	<script src="script.js" type="module"></script>
 </body>
 

--- a/maps/script.js
+++ b/maps/script.js
@@ -73,7 +73,12 @@ async function init() {
 
   const saveLocalButton = document.querySelector("#save-local-button");
   saveLocalButton.addEventListener("click", () => {
-    const location = document.querySelector("#map iframe").src;
+    const mapIframe = document.querySelector("#map iframe");
+    if (!mapIframe) {
+      console.error("Map iframe not found. Cannot save state.");
+      return;
+    }
+    const location = mapIframe.src;
     const caption = document.querySelector("#caption p")?.textContent || "";
     const content = `Location: ${location}\nCaption: ${caption}`;
     const blob = new Blob([content], { type: "text/plain" });

--- a/maps/script.js
+++ b/maps/script.js
@@ -70,6 +70,20 @@ async function init() {
   } else {
     document.documentElement.setAttribute("data-theme", "light");
   }
+
+  const saveLocalButton = document.querySelector("#save-local-button");
+  saveLocalButton.addEventListener("click", () => {
+    const location = document.querySelector("#map iframe").src;
+    const caption = document.querySelector("#caption p")?.textContent || "";
+    const content = `Location: ${location}\nCaption: ${caption}`;
+    const blob = new Blob([content], { type: "text/plain" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "map-data.txt";
+    a.click();
+    URL.revokeObjectURL(url);
+  });
 }
 
 init();

--- a/spatial/src/TopBar.tsx
+++ b/spatial/src/TopBar.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { useAtom } from "jotai";
-import { useResetState } from "./hooks";
+import { useResetState, useSaveState } from "./hooks";
 import {
   DetectTypeAtom,
   HoverEnteredAtom,
@@ -25,6 +25,7 @@ import { modelOptions } from "./consts";
 
 export function TopBar() {
   const resetState = useResetState();
+  const saveState = useSaveState();
   const [revealOnHover, setRevealOnHoverMode] = useAtom(RevealOnHoverModeAtom);
   const [detectType] = useAtom(DetectTypeAtom);
   const [, setHoverEntered] = useAtom(HoverEnteredAtom);
@@ -44,6 +45,17 @@ export function TopBar() {
           }}
         >
           <div>Reset session</div>
+        </button>
+        <button
+          onClick={() => {
+            saveState();
+          }}
+          className="p-0 border-none underline bg-transparent"
+          style={{
+            minHeight: "0",
+          }}
+        >
+          <div>Save to Local</div>
         </button>
       </div>
       <div className="flex gap-3 items-center">

--- a/spatial/src/hooks.tsx
+++ b/spatial/src/hooks.tsx
@@ -19,6 +19,9 @@ import {
   BumpSessionAtom,
   ImageSentAtom,
   PointsAtom,
+  ImageSrcAtom,
+  LinesAtom,
+  DetectTypeAtom,
 } from "./atoms";
 
 export function useResetState() {
@@ -34,5 +37,34 @@ export function useResetState() {
     setBoundingBoxes3D([]);
     setBumpSession((prev) => prev + 1);
     setPoints([]);
+  };
+}
+
+export function useSaveState() {
+  const [imageSrc] = useAtom(ImageSrcAtom);
+  const [boundingBoxes2D] = useAtom(BoundingBoxes2DAtom);
+  const [boundingBoxes3D] = useAtom(BoundingBoxes3DAtom);
+  const [points] = useAtom(PointsAtom);
+  const [lines] = useAtom(LinesAtom);
+  const [detectType] = useAtom(DetectTypeAtom);
+
+  return () => {
+    const state = {
+      imageSrc,
+      boundingBoxes2D,
+      boundingBoxes3D,
+      points,
+      lines,
+      detectType,
+    };
+
+    const content = JSON.stringify(state, null, 2);
+    const blob = new Blob([content], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "spatial-data.json";
+    a.click();
+    URL.revokeObjectURL(url);
   };
 }

--- a/video/src/App.jsx
+++ b/video/src/App.jsx
@@ -47,6 +47,28 @@ export default function App() {
   const isCustomChartMode = isChartMode && chartMode === 'Custom'
   const hasSubMode = isCustomMode || isChartMode
 
+  const saveState = () => {
+    const state = {
+      vidUrl,
+      timecodeList,
+      selectedMode,
+      activeMode,
+      customPrompt,
+      chartMode,
+      chartPrompt,
+      chartLabel,
+    };
+
+    const content = JSON.stringify(state, null, 2);
+    const blob = new Blob([content], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "video-data.json";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
   const setTimecodes = ({timecodes}) =>
     setTimecodeList(
       timecodes.map(t => ({...t, text: t.text.replaceAll("\\'", "'")}))
@@ -237,6 +259,12 @@ export default function App() {
                       onClick={() => onModeSelect(selectedMode)}
                     >
                       ▶️ Generate
+                    </button>
+                    <button
+                      className="button saveButton"
+                      onClick={saveState}
+                    >
+                      💾 Save to Local
                     </button>
                   </div>
                 </>


### PR DESCRIPTION
**Title:**  
Add “Save to Local” Button to Prevent Losing Work

**Description:**  
Hey everyone! 👋

So, after seeing that people were worried about possibly losing their work because saving to Google Drive isn’t super reliable in AI Studio, I wanted to help out. I looked through the code and realized that the app itself doesn’t control Drive stuff—that’s handled somewhere else. Since I couldn’t fix Google Drive, I decided to make it way easier (and safer) to save your own progress!

Here’s what I changed for each applet:

- **Maps Applet:**  
  Added a “Save to Local” button you can click whenever. It saves the map’s location and its caption into a small text file—so you can always keep a copy on your computer and not stress about losing your spot.

- **Spatial Applet:**  
  There’s a new “Save to Local” button up top. When you click it, it grabs literally everything in your session—images, boxes, lines, whatever—and saves it as a JSON file. So you’ve got a full backup and can pick up where you left off even if something breaks.

- **Video Applet:**  
  I added the same kind of button next to “Generate.” It saves all your session info (video link, all timecodes, your notes, etc.) into a JSON file, so your video work is safe.

I know it doesn’t fix Google Drive itself, but at least now you won’t lose your progress—even if Drive lets you down. Hope this makes things feel way safer and takes some stress off. If there’s anything else I can do to help with saving or backing up, just let me know!

Thanks for checking it out! 

Let me know if you want it even more informal, but this keeps it helpful, positive, and clear with a good “young dev” vibe.

for this issues :

https://github.com/google-gemini/starter-applets/issues/32
