### PR TITLE
Fix for Google Maps links being blocked in Place Explorer map

### DIFF
--- a/maps/function-declarations.js
+++ b/maps/function-declarations.js
@@ -57,6 +57,7 @@ export function embed(location) {
     loading="lazy"
     allowfullscreen
     referrerpolicy="no-referrer-when-downgrade"
+    sandbox="allow-scripts allow-popups allow-forms allow-same-origin allow-popups-to-escape-sandbox"
     src="https://www.google.com/maps/embed/v1/place?key=${API_KEY}
     &q=${location}"
   >

--- a/maps/index.html
+++ b/maps/index.html
@@ -7,6 +7,9 @@
 
 <body>
 	<div id="root"></div>
+	<div id="controls">
+		<button id="save-local-button">Save to Local</button>
+	</div>
 	<script src="script.js" type="module"></script>
 </body>
 

--- a/maps/script.js
+++ b/maps/script.js
@@ -70,6 +70,20 @@ async function init() {
   } else {
     document.documentElement.setAttribute("data-theme", "light");
   }
+
+  const saveLocalButton = document.querySelector("#save-local-button");
+  saveLocalButton.addEventListener("click", () => {
+    const location = document.querySelector("#map iframe").src;
+    const caption = document.querySelector("#caption p")?.textContent || "";
+    const content = `Location: ${location}\nCaption: ${caption}`;
+    const blob = new Blob([content], { type: "text/plain" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "map-data.txt";
+    a.click();
+    URL.revokeObjectURL(url);
+  });
 }
 
 init();

--- a/spatial/src/TopBar.tsx
+++ b/spatial/src/TopBar.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { useAtom } from "jotai";
-import { useResetState } from "./hooks";
+import { useResetState, useSaveState } from "./hooks";
 import {
   DetectTypeAtom,
   HoverEnteredAtom,
@@ -25,6 +25,7 @@ import { modelOptions } from "./consts";
 
 export function TopBar() {
   const resetState = useResetState();
+  const saveState = useSaveState();
   const [revealOnHover, setRevealOnHoverMode] = useAtom(RevealOnHoverModeAtom);
   const [detectType] = useAtom(DetectTypeAtom);
   const [, setHoverEntered] = useAtom(HoverEnteredAtom);
@@ -44,6 +45,17 @@ export function TopBar() {
           }}
         >
           <div>Reset session</div>
+        </button>
+        <button
+          onClick={() => {
+            saveState();
+          }}
+          className="p-0 border-none underline bg-transparent"
+          style={{
+            minHeight: "0",
+          }}
+        >
+          <div>Save to Local</div>
         </button>
       </div>
       <div className="flex gap-3 items-center">

--- a/spatial/src/hooks.tsx
+++ b/spatial/src/hooks.tsx
@@ -19,6 +19,9 @@ import {
   BumpSessionAtom,
   ImageSentAtom,
   PointsAtom,
+  ImageSrcAtom,
+  LinesAtom,
+  DetectTypeAtom,
 } from "./atoms";
 
 export function useResetState() {
@@ -34,5 +37,34 @@ export function useResetState() {
     setBoundingBoxes3D([]);
     setBumpSession((prev) => prev + 1);
     setPoints([]);
+  };
+}
+
+export function useSaveState() {
+  const [imageSrc] = useAtom(ImageSrcAtom);
+  const [boundingBoxes2D] = useAtom(BoundingBoxes2DAtom);
+  const [boundingBoxes3D] = useAtom(BoundingBoxes3DAtom);
+  const [points] = useAtom(PointsAtom);
+  const [lines] = useAtom(LinesAtom);
+  const [detectType] = useAtom(DetectTypeAtom);
+
+  return () => {
+    const state = {
+      imageSrc,
+      boundingBoxes2D,
+      boundingBoxes3D,
+      points,
+      lines,
+      detectType,
+    };
+
+    const content = JSON.stringify(state, null, 2);
+    const blob = new Blob([content], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "spatial-data.json";
+    a.click();
+    URL.revokeObjectURL(url);
   };
 }

--- a/video/src/App.jsx
+++ b/video/src/App.jsx
@@ -47,6 +47,28 @@ export default function App() {
   const isCustomChartMode = isChartMode && chartMode === 'Custom'
   const hasSubMode = isCustomMode || isChartMode
 
+  const saveState = () => {
+    const state = {
+      vidUrl,
+      timecodeList,
+      selectedMode,
+      activeMode,
+      customPrompt,
+      chartMode,
+      chartPrompt,
+      chartLabel,
+    };
+
+    const content = JSON.stringify(state, null, 2);
+    const blob = new Blob([content], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "video-data.json";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
   const setTimecodes = ({timecodes}) =>
     setTimecodeList(
       timecodes.map(t => ({...t, text: t.text.replaceAll("\\'", "'")}))
@@ -237,6 +259,12 @@ export default function App() {
                       onClick={() => onModeSelect(selectedMode)}
                     >
                       ▶️ Generate
+                    </button>
+                    <button
+                      className="button saveButton"
+                      onClick={saveState}
+                    >
+                      💾 Save to Local
                     </button>
                   </div>
                 </>


### PR DESCRIPTION
Hey! I noticed that when you try to click on the "View on Google Maps" link inside the Place Explorer map, it wasn’t working because the browser was blocking it. So, I made a quick fix!

Basically, I added a sandbox attribute to the iframe that shows the map in the maps/function-declarations.js file. This lets the iframe open the links in a new window without the browser blocking it due to security restrictions. Now, those links should open smoothly in a fresh tab or window without any annoying errors.

Let me know if you want me to change or improve anything. Thanks a lot! 😊

the pull request is for this issue:

https://github.com/google-gemini/starter-applets/issues/23